### PR TITLE
config: Setup soong namespaces for TARGET_USE_QTI_BT_STACK

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -99,3 +99,9 @@ PRODUCT_SOONG_NAMESPACES += \
 ifeq ($(TARGET_HW_DISK_ENCRYPTION),true)
     TARGET_CRYPTFS_HW_PATH ?= vendor/qcom/opensource/cryptfs_hw
 endif
+
+ifeq ($(TARGET_USE_QTI_BT_STACK),true)
+PRODUCT_SOONG_NAMESPACES += \
+    vendor/qcom/opensource/commonsys/packages/apps/Bluetooth \
+    vendor/qcom/opensource/commonsys/system/bt/conf
+endif #TARGET_USE_QTI_BT_STACK

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -62,3 +62,7 @@ SOONG_CONFIG_mikuGlobalVars_qcom_display_headers_namespace := vendor/qcom/openso
 else
 SOONG_CONFIG_mikuGlobalVars_qcom_display_headers_namespace := $(QCOM_SOONG_NAMESPACE)/display
 endif
+
+ifneq ($(TARGET_USE_QTI_BT_STACK),true)
+PRODUCT_SOONG_NAMESPACES += packages/apps/Bluetooth
+endif #TARGET_USE_QTI_BT_STACK


### PR DESCRIPTION
To opt-in for QTI BT addons, enable TARGET_USE_QTI_BT_STACK in BoardConfig.mk

Reference: [https://github.com/LineageOS/android_vendor_qcom_opensource_bluetooth-commonsys-intf/blob/lineage-18.0/bt-system-opensource-product.mk]

Change-Id: I6bf3e1dda6fe5dc66f6fafdb32a1daecb9616c84